### PR TITLE
Hacks that get otelsdk building with brew protobuf on a Mac

### DIFF
--- a/configure
+++ b/configure
@@ -50,7 +50,7 @@ if [ "$UNAME" = "Windows" ]; then
     XCXXFLAGS="-DCURL_STATICLIB"
 elif [ "$UNAME" = "Darwin" ]; then
     CMAKE_PREFIX_PATH="/opt/R/`arch`"
-    PROTOBUF_LIBS="-lprotobuf"
+    PROTOBUF_LIBS="`pkg-config --libs protobuf --cflags`"
     LIBCURL_LIBS="-lcurl"
 else
     PROTOBUF_LIBS="`pkg-config --libs protobuf || echo '-lprotobuf'`"

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -27,7 +27,7 @@ OBJECTS = init.o cleancall.o wrap-r.o wrap-c.o glue.o utils.o errors.o \
 	meter.o meter-sdk.o	logger.o logger-sdk.o \
 	r-collector.o collector.o
 
-PKG_CPPFLAGS = -Iinstall/include -DOPENTELEMETRY_ABI_VERSION_NO=2
+PKG_CPPFLAGS = -Iinstall/include -DOPENTELEMETRY_ABI_VERSION_NO=2 -I/opt/homebrew/Cellar/protobuf/29.3/include/ -I/opt/homebrew/Cellar/abseil/20240722.1/include/
 PKG_CFLAGS += @PKG_CFLAGS@
 PKG_CXXFLAGS += @PKG_CXXFLAGS@
 PKG_LIBS = \


### PR DESCRIPTION
Hacks, do not merge, just use this to get unstuck

@schloerke and @jcheng5 you may still need to clone this PR and tweak the precise version of protobuf and abseil, but this got me and @schloerke a successfull build of otelsdk on a Mac with brew protobuf

Using this hint:
https://github.com/protocolbuffers/protobuf/issues/17258#issuecomment-2415135317

1. `brew install protobuf`, this should bring in `abseil` as well
2. Check `brew list protobuf` and look for `/opt/homebrew/Cellar/protobuf/29.3/include/`. If the versions are the same you should not have to change anything, otherwise tweak `Makevars.in`
3. Check `brew list abseil` and look for `/opt/homebrew/Cellar/abseil/20240722.1/include/`. If the versions are the same you should not have to change anything, otherwise tweak `Makevars.in`. Note that this reports `.../include/abseil` but you really just want up to `.../include/`
4. `devtools::load_all()` worked for me after that
